### PR TITLE
Fix use of lib4ti2_jll

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ env:
 dist: bionic
 
 before_install:
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; sudo apt-get install -y libglpk-dev; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; brew install glpk; fi
+# - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi # sudo apt-get install -y libglpk-dev;
+# - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi # brew install glpk;
 
 script:
   - travis_wait 60 julia --color=yes -e 'using Pkg;

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Mohamed Barakat <mohamed.barakat@uni-siegen.de>"]
 version = "0.4.0"
 
 [deps]
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 GAP = "c863536a-3901-11e9-33e7-d5cd0df7b904"
 Singular = "bcd08a7b-43d2-5ff7-b6d4-c458787f915c"
 lib4ti2_jll = "1493ae25-0f90-5c0e-a06c-8c5077d6d66f"

--- a/deps/usr/bin/graver
+++ b/deps/usr/bin/graver
@@ -1,0 +1,7 @@
+#!/bin/sh
+# graver
+julia -e 'import lib4ti2_jll
+lib4ti2_jll.zsolve() do x
+ p=run(ignorestatus(`$x -G $ARGS`))
+ exit(p.exitcode)
+end' -- "$@"

--- a/deps/usr/bin/groebner
+++ b/deps/usr/bin/groebner
@@ -1,0 +1,7 @@
+#!/bin/sh
+# groebner
+julia -e 'import lib4ti2_jll
+lib4ti2_jll.exe4ti2gmp() do x
+ p=run(ignorestatus(`$x groebner $ARGS`))
+ exit(p.exitcode)
+end' -- "$@"

--- a/deps/usr/bin/hilbert
+++ b/deps/usr/bin/hilbert
@@ -1,0 +1,7 @@
+#!/bin/sh
+# hilbert
+julia -e 'import lib4ti2_jll
+lib4ti2_jll.zsolve() do x
+ p=run(ignorestatus(`$x -H $ARGS`))
+ exit(p.exitcode)
+end' -- "$@"

--- a/deps/usr/bin/markov
+++ b/deps/usr/bin/markov
@@ -1,0 +1,7 @@
+#!/bin/sh
+# markov
+julia -e 'import lib4ti2_jll
+lib4ti2_jll.exe4ti2gmp() do x
+ p=run(ignorestatus(`$x markov $ARGS`))
+ exit(p.exitcode)
+end' -- "$@"

--- a/deps/usr/bin/zsolve
+++ b/deps/usr/bin/zsolve
@@ -1,0 +1,7 @@
+#!/bin/sh
+# graver
+julia -e 'import lib4ti2_jll
+lib4ti2_jll.zsolve() do x
+ p=run(ignorestatus(`$x $ARGS`))
+ exit(p.exitcode)
+end' -- "$@"

--- a/src/HomalgProject.jl
+++ b/src/HomalgProject.jl
@@ -74,8 +74,6 @@ import Singular.libSingular: call_interpreter
 
 export call_interpreter
 
-import lib4ti2_jll
-
 import Pkg
 import Markdown
 
@@ -98,7 +96,13 @@ include("../deps/homalg-project.jl")
 
 global SINGULAR_PATH = dirname(dirname(pathof(Singular)))
 
-global HOMALG_EXTRA_PATHS = [ lib4ti2_jll.PATH_list ]
+global HOMALG_PATHS = [ ]
+
+## $(HOMALG_PROJECT_PATH)/deps/usr/bin should be the last entry
+HOMALG_PATHS = vcat( HOMALG_PATHS,
+                           [ [ joinpath(HOMALG_PROJECT_PATH,"deps","usr","bin") ] ] )
+
+export HOMALG_PATHS
 
 ##
 function UseExternalSingular( bool::Bool )
@@ -188,8 +192,8 @@ function __init__()
     ## add "~/.julia/.../HomalgProject/" at the beginning of GAPInfo.RootPaths
     GAP.Globals.EnhanceRootDirectories( GAP.julia_to_gap( [ GAP.julia_to_gap( HOMALG_PROJECT_PATH * "/" ) ] ) )
     
-    ## add ~/.julia/artifacts/*/bin to GAPInfo.DirectoriesSystemPrograms
-    for paths in HOMALG_EXTRA_PATHS
+    ## add more paths to GAPInfo.DirectoriesSystemPrograms
+    for paths in HOMALG_PATHS
         paths = GAP.Globals.List( GAP.julia_to_gap( paths ), GAP.julia_to_gap )
         paths = GAP.Globals.Concatenation( paths, GAP.Globals.GAPInfo.DirectoriesSystemPrograms )
         paths = GAP.Globals.Unique( paths )


### PR DESCRIPTION
Use the exported functions of ExecutableProducts to
properly set the appropriate environment variables
as described in

https://julialang.org/blog/2019/11/artifacts/

Closes #18