### PR TITLE
outsourced GAP conversions into a separate file

### DIFF
--- a/src/HomalgProject.jl
+++ b/src/HomalgProject.jl
@@ -88,17 +88,7 @@ end
 
 export LoadPackage
 
-function HomalgMatrix(M::String, m::Int64, n::Int64, R::GAP.GapObj)
-    return GAP.Globals.HomalgMatrix(julia_to_gap(M), m, n, R)
-end
-
-export HomalgMatrix
-
-function SizeScreen(L::Array)
-    return GAP.Globals.SizeScreen(julia_to_gap(L))
-end
-
-export SizeScreen
+include("conversions.jl")
 
 include(joinpath("..","deps","homalg-project.jl"))
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -1,0 +1,17 @@
+function HomalgMatrix(M::String, m::Int64, n::Int64, R::GAP.GapObj)
+    return GAP.Globals.HomalgMatrix(julia_to_gap(M), m, n, R)
+end
+
+export HomalgMatrix
+
+function RepresentationCategoryObject(char::GAP.GapObj, category::GAP.GapObj, name::String)
+    return GAP.Globals.RepresentationCategoryObject(char, category, julia_to_gap(name))
+end
+
+export RepresentationCategoryObject
+
+function SizeScreen(L::Array)
+    return GAP.Globals.SizeScreen(julia_to_gap(L))
+end
+
+export SizeScreen


### PR DESCRIPTION
the content should become obsolete once GAP.jl converts Julia strings
automatically to GAP strings (or another technical solution with a similar effect)